### PR TITLE
Removed logger because it cannot be used in a PL/JAVA-Function 

### DIFF
--- a/src/main/antlr4/org/sep3tools/gen/PetroGrammar.g4
+++ b/src/main/antlr4/org/sep3tools/gen/PetroGrammar.g4
@@ -22,24 +22,10 @@ attribute:
 uebergang_att: attribut '-' attribut;
 
 attribut:
-    ATTRIBUT            # attr
-    | UNBEKANNT         # attr_unbek
+    TEIL                # attr
     | attribut FRAGLICH # attr_fraglich
     | attribut SICHER   # attr_sicher
-    ;
-
-ATTRIBUT:
-    't'
-    |'lw'
-    |'r2'
-    |'r3'
-    |'tw'
-    |'gs'
-    |'nf'
-    |'bei'
-    |'tv'
-    |'tb'
-    |TIEFE
+    | TIEFE             # attr_tiefe
     ;
 
 TIEFE: ([0-9]|'.')+;

--- a/src/main/java/org/sep3tools/Launch.java
+++ b/src/main/java/org/sep3tools/Launch.java
@@ -1,12 +1,10 @@
 package org.sep3tools;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.sep3tools.gen.PetroGrammarLexer;
-import org.sep3tools.gen.PetroGrammarParser;
+import org.sep3tools.gen.*;
 
 public class Launch {
 
@@ -26,6 +24,12 @@ public class Launch {
 
 		PetroVisitor visitor = new PetroVisitor();
 		return (visitor.visit(tree));
+	}
+
+	public static String parseS3(String wb, String st, String s3String) {
+		PLJavaConnector.setWb(wb);
+		PLJavaConnector.setSt(st);
+		return parseS3(s3String);
 	}
 
 }

--- a/src/main/java/org/sep3tools/PLJavaConnector.java
+++ b/src/main/java/org/sep3tools/PLJavaConnector.java
@@ -4,23 +4,38 @@ import java.sql.*;
 
 public class PLJavaConnector {
 
-	private static String m_url = "jdbc:default:connection";
+    private static String m_url = "jdbc:default:connection";
+    private static String wb = "woerterbuch.\"Woerterbuch\"";
+    private static String st = "woerterbuch.\"Schluesseltypen\"";
 
-	public static String getS3Name(String sep3Code) throws SQLException {
-		Connection conn = DriverManager.getConnection(m_url);
-		String query = "SELECT sep3_term from bml.bml_schluesselmapping where bml_codelist='RockNameList' and sep3_code=";
+    public static void setWb(String wb) {
+        PLJavaConnector.wb = wb;
+    }
 
-		PreparedStatement stmt = conn.prepareStatement(query + "'" + sep3Code + "'");
-		ResultSet rs = stmt.executeQuery();
-		rs.next();
-		String ret;
-		ret = rs.getString("sep3_term");
+    public static void setSt(String st) {
+        PLJavaConnector.st = st;
+    }
 
-		stmt.close();
-		conn.close();
+    public static String getS3Name(String sep3Code) throws SQLException {
 
-		return (ret);
+        Connection conn = DriverManager.getConnection(m_url);
+        //String query = "SELECT Klartext from woerterbuch.Woerterbuch where Kuerzel=";
+        String query = "select \"Kuerzel\", \"Klartext\" from "+ wb + " w join " + st + " s " +
+                "on w.\"Typ\" = s.\"Nebentypbez\" " +
+                "where s.\"Datenfeld\" = 'PETRO' AND \"Kuerzel\"=";
 
-	}
+        PreparedStatement stmt = conn.prepareStatement(query + "'" + sep3Code + "'");
+        ResultSet rs = stmt.executeQuery();
+        boolean validRS = rs.next();
+        String ret = "";
+        if (validRS)
+            ret = rs.getString(2);
+
+        stmt.close();
+        conn.close();
+
+        return (ret);
+
+    }
 
 }

--- a/src/test/java/org/sep3tools/LaunchTest.java
+++ b/src/test/java/org/sep3tools/LaunchTest.java
@@ -16,7 +16,7 @@ public class LaunchTest {
 		String parsed = Launch.parseS3(sep3String);
 
 		assertThat(parsed, CoreMatchers.is(
-				"Mittelsandstein (kantengerundet, mäßig gerundet (teilweise), grobsandig (lagenweise, kantengerundet bis mäßig gerundet)), Schluff (tonig, lagenweise), Grobsandstein (mäßig gerundet, bei (113), Nachfall (fraglich))"));
+				"Mittelsandstein (kantengerundet, mäßig gerundet (teilweise), grobsandig (lagenweise, kantengerundet bis mäßig gerundet)), Schluffstein (tonig, lagenweise), Grobsandstein (mäßig gerundet, bei (113), Nachfall (fraglich))"));
 	}
 
 }


### PR DESCRIPTION
Removed logger because it cannot be used in a PL/JAVA-Function in PostgeSQL.

- changed grammar to allow attribute retrieval from database
- changed database query string to retrieve from 'woerterbuch'-tables (download link in docs)
- added possibility to set table names in function call