### PR TITLE
Improved error handling and verbose method introduced

### DIFF
--- a/src/main/java/org/sep3tools/Launch.java
+++ b/src/main/java/org/sep3tools/Launch.java
@@ -55,8 +55,7 @@ public class Launch {
 	 * @param s3String coded SEP3 string parsing
 	 * @return human readable format of SEP3 input
 	 */
-	@Function
-	public static String S3_AsText(String s3String) {
+	protected static String S3_AsText(String s3String) {
 		CharStream input = CharStreams.fromString(s3String);
 		PetroGrammarLexer lexer = new PetroGrammarLexer(input);
 		CommonTokenStream tokens = new CommonTokenStream(lexer);
@@ -69,7 +68,7 @@ public class Launch {
 
 	/**
 	 * translates a coded SEP3 String to a human readable format. needed for in database
-	 * use
+	 * use. Returns empty String, if exception is catched.
 	 * @param s3String coded SEP3 string parsing
 	 * @param st Schluesseltypen table
 	 * @param wb Woerterbuch table
@@ -77,6 +76,26 @@ public class Launch {
 	 */
 	@Function
 	public static String S3_AsText(String s3String, String wb, String st) {
+		try {
+			JavaConnector.setWb(wb);
+			JavaConnector.setSt(st);
+			return S3_AsText(s3String);
+		}
+		catch (Exception e) {
+			return "";
+		}
+	}
+
+	/**
+	 * translates a coded SEP3 String to a human readable format. needed for in database
+	 * use
+	 * @param s3String coded SEP3 string parsing
+	 * @param st Schluesseltypen table
+	 * @param wb Woerterbuch table
+	 * @return human readable format of SEP3 input
+	 */
+	@Function
+	public static String S3_AsText_verbose(String s3String, String wb, String st) {
 		JavaConnector.setWb(wb);
 		JavaConnector.setSt(st);
 		return S3_AsText(s3String);

--- a/src/main/java/org/sep3tools/LaunchBML.java
+++ b/src/main/java/org/sep3tools/LaunchBML.java
@@ -3,7 +3,6 @@ package org.sep3tools;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.misc.NotNull;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.postgresql.pljava.annotation.Function;
 import org.sep3tools.gen.PetroGrammarLexer;
@@ -57,8 +56,7 @@ public class LaunchBML {
 	 * @param s3String coded SEP3 string parsing
 	 * @return BML format of SEP3 input
 	 */
-	@Function
-	public static String S3_AsBmlLitho(String s3String) {
+	protected static String S3_AsBmlLitho(String s3String) {
 		CharStream input = CharStreams.fromString(s3String);
 		PetroGrammarLexer lexer = new PetroGrammarLexer(input);
 		CommonTokenStream tokens = new CommonTokenStream(lexer);

--- a/src/main/java/org/sep3tools/LaunchBML.java
+++ b/src/main/java/org/sep3tools/LaunchBML.java
@@ -87,6 +87,9 @@ public class LaunchBML {
 		if (resultString.startsWith(",")) {
 			resultString = resultString.substring(1);
 		}
+		if (resultString.endsWith(",")) {
+			resultString = resultString.substring(0, resultString.length() - 1);
+		}
 		return resultString;
 	}
 


### PR DESCRIPTION
This PR improves the error handling. The methods `S3_AsText` and `S3_AsBmlLitho` with single parameter have been set to protected and are no longer available as PL/Java Function. New  function `S3_AsText_verbose` introduced.