### PR TITLE
Changed grammar to accept brackets for single soil, enumeration and crossover

### DIFF
--- a/src/main/antlr4/org/sep3tools/gen/PetroGrammar.g4
+++ b/src/main/antlr4/org/sep3tools/gen/PetroGrammar.g4
@@ -3,21 +3,26 @@ grammar PetroGrammar;
 schichtbeschreibung: bestandteile;
 
 bestandteile:
-    bestandteil ( '(' attribute ')' )?    # Teil
-    | bestandteile ',' bestandteile     # Aufzaehlung_b
-    | uebergang_bes ( '(' attribute ')' )?  # Uebergang_b
-
+    bestandteil                                                     # Teil
+    | bestandteile ',' bestandteile                                 # Aufzaehlung_b
+    | '(' bestandteile ',' bestandteile ')' ( '(' attribute ')' )?  # Aufzaehlung_b_k
+    | uebergang_bes                                                 # Uebergang_b
 ;
 
-uebergang_bes: b1=bestandteil '-' b2=bestandteil;
+uebergang_bes:
+    b1=bestandteil  '-' b2=bestandteil
+    | '(' uebergang_bes ')' ( '(' attribute ')' )?
+;
 
-bestandteil: TEIL;
+bestandteil:
+    TEIL ( '(' attribute ')' )?
+    | '(' TEIL  ( '(' attribute ')' )? ')';
 
 attribute:
     attribut                                    # att
     | uebergang_att                             # Uebergang_a
     | attr=attribute '(' unter=attribute ')'    # unter_Attribute
-    | attribute ',' attribute                  # Aufzaehlung_a
+    | attribute ',' attribute                   # Aufzaehlung_a
 ;
 uebergang_att: attribut '-' attribut;
 

--- a/src/main/java/org/sep3tools/BmlVisitor.java
+++ b/src/main/java/org/sep3tools/BmlVisitor.java
@@ -53,7 +53,27 @@ public class BmlVisitor extends PetroGrammarBaseVisitor<String> {
 	 */
 	@Override
 	public String visitBestandteil(PetroGrammarParser.BestandteilContext ctx) {
-		String boden = ctx.getText();
+		String boden = getBodenTerm(ctx.TEIL().getText());
+		String attrib;
+		if (isNull(ctx.attribute())) {
+			return boden;
+		}
+		else {
+			String attr = visit(ctx.attribute());
+			if (isNull(attr)) {
+				return boden;
+			}
+			else if (attr.startsWith(" (")) {
+				attrib = attr.substring(2, attr.length() - 1);
+			}
+			else {
+				attrib = attr;
+			}
+		}
+		return boden + "," + attrib;
+	}
+
+	private String getBodenTerm(String boden) {
 		String bodenTerm = getBmlResultSet(boden);
 		if (!bodenTerm.isEmpty())
 			return bodenTerm;
@@ -102,7 +122,31 @@ public class BmlVisitor extends PetroGrammarBaseVisitor<String> {
 	 */
 	@Override
 	public String visitUebergang_bes(PetroGrammarParser.Uebergang_besContext ctx) {
-		return visit(ctx.b1) + ", " + visit(ctx.b2);
+		String teile;
+		String attrib;
+
+		if (ctx.getText().startsWith(" (")) {
+			teile = visit(ctx.uebergang_bes());
+		}
+		else {
+			teile = visit(ctx.b1) + ", " + visit(ctx.b2);
+		}
+		if (isNull(ctx.attribute())) {
+			attrib = "";
+		}
+		else {
+			String attr = visit(ctx.attribute());
+			if (isNull(attr)) {
+				attrib = "";
+			}
+			else if (attr.startsWith(" (")) {
+				attrib = attr.substring(2, attr.length() - 1);
+			}
+			else {
+				attrib = attr;
+			}
+		}
+		return teile + attrib;
 	}
 
 	/**
@@ -122,18 +166,7 @@ public class BmlVisitor extends PetroGrammarBaseVisitor<String> {
 	 */
 	@Override
 	public String visitUebergang_b(PetroGrammarParser.Uebergang_bContext ctx) {
-		String teil = visit(ctx.uebergang_bes());
-
-		if (isNull(ctx.attribute()))
-			return teil;
-
-		String attr = visit(ctx.attribute());
-		if (isNull(attr))
-			return teil;
-
-		if (attr.startsWith(" ("))
-			return teil + attr;
-		return teil + ", " + attr;
+		return visit(ctx.uebergang_bes());
 	}
 
 	/**
@@ -143,16 +176,7 @@ public class BmlVisitor extends PetroGrammarBaseVisitor<String> {
 	 */
 	@Override
 	public String visitTeil(PetroGrammarParser.TeilContext ctx) {
-		String teil = visit(ctx.bestandteil());
-
-		if (isNull(ctx.attribute()))
-			return teil;
-
-		String attr = visit(ctx.attribute());
-		if (isNull(attr))
-			return teil;
-
-		return teil + "," + attr;
+		return visit(ctx.bestandteil());
 	}
 
 	/**

--- a/src/main/java/org/sep3tools/PetroVisitor.java
+++ b/src/main/java/org/sep3tools/PetroVisitor.java
@@ -53,7 +53,29 @@ public class PetroVisitor extends PetroGrammarBaseVisitor<String> {
 	 */
 	@Override
 	public String visitBestandteil(PetroGrammarParser.BestandteilContext ctx) {
-		String boden = ctx.getText();
+		String boden = getBodenTerm(ctx.TEIL().getText());
+		String attrib;
+		if (isNull(ctx.attribute())) {
+			attrib = "";
+		}
+		else {
+			String attr = visit(ctx.attribute());
+			if (isNull(attr)) {
+				attrib = "";
+			}
+			else if (attr.trim().startsWith("(")) {
+				attrib = attr;
+			}
+			else {
+				attrib = " (" + attr + ")";
+			}
+		}
+		// if (ctx.getText().startsWith("("))
+		// return "(" + boden + attrib + ")";
+		return boden + attrib;
+	}
+
+	private String getBodenTerm(String boden) {
 		String bodenTerm = getS3ResultSet(boden);
 		if (!bodenTerm.isEmpty())
 			return bodenTerm;
@@ -75,7 +97,6 @@ public class PetroVisitor extends PetroGrammarBaseVisitor<String> {
 				}
 			}
 		}
-
 		switch (boden) {
 			case "^u":
 				return "Schluffstein";
@@ -149,7 +170,31 @@ public class PetroVisitor extends PetroGrammarBaseVisitor<String> {
 	 */
 	@Override
 	public String visitUebergang_bes(PetroGrammarParser.Uebergang_besContext ctx) {
-		return visit(ctx.b1) + " bis " + visit(ctx.b2);
+		String teile;
+		String attrib;
+		if (ctx.getText().trim().startsWith("(")) {
+			teile = "(" + visit(ctx.uebergang_bes()) + ")";
+		}
+		else {
+			teile = visit(ctx.b1) + " bis " + visit(ctx.b2);
+		}
+
+		if (isNull(ctx.attribute())) {
+			attrib = "";
+		}
+		else {
+			String attr = visit(ctx.attribute());
+			if (isNull(attr)) {
+				attrib = "";
+			}
+			else if (attr.trim().startsWith("(")) {
+				attrib = attr;
+			}
+			else {
+				attrib = " (" + attr + ")";
+			}
+		}
+		return teile + attrib;
 	}
 
 	/**
@@ -163,24 +208,43 @@ public class PetroVisitor extends PetroGrammarBaseVisitor<String> {
 	}
 
 	/**
+	 * process enumeration (aufzaehlung) of soil in brackets
+	 * @param ctx the parse tree
+	 * @return translated string for soil enumeration parse tree
+	 */
+	@Override
+	public String visitAufzaehlung_b_k(PetroGrammarParser.Aufzaehlung_b_kContext ctx) {
+		String aufz;
+		String attrib;
+
+		aufz = "(" + visit(ctx.bestandteile(0)) + ", " + visit(ctx.bestandteile(1)) + ")";
+		if (isNull(ctx.attribute())) {
+			attrib = "";
+		}
+		else {
+			String attr = visit(ctx.attribute());
+			if (isNull(attr)) {
+				attrib = "";
+			}
+			else if (attr.trim().startsWith("(")) {
+				attrib = attr;
+			}
+			else {
+				attrib = " (" + attr + ")";
+			}
+		}
+		return aufz + attrib;
+
+	}
+
+	/**
 	 * process transition (uebergang) for soil with attributes
 	 * @param ctx the parse tree
 	 * @return translated string for transition parse tree
 	 */
 	@Override
 	public String visitUebergang_b(PetroGrammarParser.Uebergang_bContext ctx) {
-		String teil = visit(ctx.uebergang_bes());
-
-		if (isNull(ctx.attribute()))
-			return teil;
-
-		String attr = visit(ctx.attribute());
-		if (isNull(attr))
-			return teil;
-
-		if (attr.startsWith(" ("))
-			return teil + attr;
-		return teil + " (" + attr + ")";
+		return visit(ctx.uebergang_bes());
 	}
 
 	/**
@@ -190,18 +254,7 @@ public class PetroVisitor extends PetroGrammarBaseVisitor<String> {
 	 */
 	@Override
 	public String visitTeil(PetroGrammarParser.TeilContext ctx) {
-		String teil = visit(ctx.bestandteil());
-
-		if (isNull(ctx.attribute()))
-			return teil;
-
-		String attr = visit(ctx.attribute());
-		if (isNull(attr))
-			return teil;
-
-		if (attr.startsWith(" ("))
-			return teil + attr;
-		return teil + " (" + attr + ")";
+		return visit(ctx.bestandteil());
 	}
 
 	/**


### PR DESCRIPTION
This PR is changing the grammar to accept brackets for single soil, enumeration and crossover. Changes to PetroVisitor and BmlVisitor to reflect the grammar changes.