### PR TITLE
Upgrade pljava to v1.6.6

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,6 +24,8 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B verify --file pom.xml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ sep3=# select "Typ", "Langtext" as "Typbezeichnung", "Kuerzel", "Klartext" from 
 
 ### Building
 
-To build SEP3-Tools you need to install a [JDK 11](https://adoptium.net/?variant=openjdk11&jvmVariant=hotspot) and [Apache Maven 3.8.x](https://maven.apache.org/).
+To build SEP3-Tools you need to install a [JDK 11](https://adoptium.net/?variant=openjdk11&jvmVariant=hotspot) and [Apache Maven 3.9.x](https://maven.apache.org/).
 Then run the following command to build the parser:
 
 ```shell
 mvn clean install
 ```
+_**NOTE:**_ Downloading dependencies from GitHub Repositories require a `GITHUB_TOKEN` set in your local Maven `settings.xml` file, see [Working with the Apache Maven registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry) for more information.
 
 To execute the parser you have to download ANTLR and all other dependencies first with:
 
@@ -89,7 +90,7 @@ for example:
 ```shell
 $> java -jar ./target/sep3-parser-0.0.1-SNAPSHOT.jar "^u(t,lw)"
 2021-09-14 12:00:00 WARN  org.sep3tools.PetroVisitor:20 - Dictionary is not available, fallback to internal dictionary if possible.
-Schluff (tonig, lagenweise)
+Schluffstein (tonig, lagenweise)
 ```
 or using the Woerterbuch data with the options `sep3-parser [jdbc-url] [username] [password] [dictionary] [keytypes] <soil_codes>`:
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
-        <pljava.version>1.6.4</pljava.version>
+        <pljava.version>1.6.6</pljava.version>
         <antlr.version>4.13.1</antlr.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,9 @@
 
     <repositories>
         <repository>
-            <id>github-repo</id>
-            <name>Github local repo for API build from https://github.com/tada/pljava/</name>
-            <url>https://raw.github.com/lat-lon/sep3-tools/repository</url>
+            <id>github</id>
+            <name>Github repo for pljava build forked from https://github.com/tada/pljava/</name>
+            <url>https://maven.pkg.github.com/lat-lon/pljava</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
@@ -47,36 +47,12 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>latlon</id>
-            <url>https://repo.lat-lon.de/repository/maven-public/</url>
-            <releases>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>sep3tools-releases</id>
-            <url>https://repo.lat-lon.de/repository/sep3tools-releases/</url>
-            <releases>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-        </repository>
     </repositories>
 
     <issueManagement>
         <system>github</system>
         <url>https://github.com/lat-lon/sep3-tools/issues</url>
     </issueManagement>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>latlon</id>
-            <url>https://repo.lat-lon.de/repository/maven-public/</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
Fixes #54 - upgrade to pljava v1.6.6 and uses github maven repo instead of branch on current repo, removes also lat/lon repos from pom.xml.
After merging the PR the branch https://github.com/lat-lon/sep3-tools/tree/repository can be deleted.

NOTE: This change affects a local build which will require a `GITHUB_TOKEN` for downloading the files from https://github.com/orgs/lat-lon/packages, see [Working with the Apache Maven registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry) for more information.
