### PR TITLE
Added and execute 00_dbinfo.sql in Dockerfile; added missing JavaConnector.setPropertiesFromDB()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN unzip /tmp/sep3examples.zip -d /tmp
 COPY ./target/sep3-parser-*-jar-with-dependencies.jar /opt/sep3-tools/sep3-parser.jar
 COPY ./install_pljava.sh /docker-entrypoint-initdb.d/install_pljava.sh
 COPY ./importData.sql /tmp/importData.sql
+COPY ./00_dbinfo.sql /tmp/00_dbinfo.sql
+COPY ./db-2.properties /tmp/db.properties
+
+RUN sed -i "s|'db-1.properties'|'/tmp/db.properties'|g" /tmp/00_dbinfo.sql
 
 RUN mdb-schema -T Schluesseltypen $WBFILENAME postgres > /tmp/Schluesseltypen_create-table.sql
 RUN mdb-export $WBFILENAME Schluesseltypen > /tmp/Schluesseltypen.csv

--- a/install_pljava.sh
+++ b/install_pljava.sh
@@ -17,3 +17,4 @@ psql -q -d sep3tools -c "SELECT sqlj.install_jar('file:///opt/sep3-tools/sep3-pa
 psql -q -d sep3tools -c "SELECT sqlj.set_classpath('public', 'sep3');"
 
 psql -q -d sep3tools -f /tmp/importData.sql
+psql -q -d sep3tools -f /tmp/00_dbinfo.sql

--- a/src/main/java/org/sep3tools/Launch.java
+++ b/src/main/java/org/sep3tools/Launch.java
@@ -83,6 +83,7 @@ public class Launch {
 	@Function
 	public static String S3_AsText(String s3String, String wb, String st, String df) {
 		try {
+			JavaConnector.setPropertiesFromDB();
 			JavaConnector.setWb(wb);
 			JavaConnector.setSt(st);
 			JavaConnector.setDf(df);
@@ -140,10 +141,16 @@ public class Launch {
 	 */
 	@Function
 	public static String S3_AsText_verbose(String s3String, String wb, String st, String df) {
-		JavaConnector.setWb(wb);
-		JavaConnector.setSt(st);
-		JavaConnector.setDf(df);
-		return S3_AsText(s3String);
+		try {
+			JavaConnector.setPropertiesFromDB();
+			JavaConnector.setWb(wb);
+			JavaConnector.setSt(st);
+			JavaConnector.setDf(df);
+			return S3_AsText(s3String);
+		}
+		catch (Exception e) {
+			return "";
+		}
 	}
 
 }


### PR DESCRIPTION
Fehler  `Caused by column w.null does not exist.` bei Aufruf der folgenden Funktion gefixt  
```
public | s3_astext         | character varying | s3string character varying, wb character varying, st character varying, df character varying | func
```

Betrifft docker Umgebung aber auch die bisherige Nutzung (war zuvor abhängig von der Reihenfolge, wurde s3_astext mit einem Argument aufgerufen, funktionierte auch der Aufruf mit vier Argumenten.