### PR TITLE
Fix push release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,4 +55,4 @@ jobs:
       with:
         context: .
         push: true
-        tags: ghcr.io/lat-lon/sep3-tools:${releaseVersion}
+        tags: ghcr.io/lat-lon/sep3-tools:${{ github.event.inputs.releaseVersion }}


### PR DESCRIPTION
```
Error: buildx failed with: ERROR: invalid tag "ghcr.io/lat-lon/sep3-tools:${releaseVersion}": invalid reference format
```
https://github.com/lat-lon/sep3-tools/actions/runs/15873170493/job/44754394764`