### PR TITLE
Configured release branch to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
         ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
+        release-branch-name: "main"
         maven-release-version-number: ${releaseVersion}
         maven-development-version-number: ${developmentVersion}
     - name: Login to GitHub Container Registry


### PR DESCRIPTION
Maven release is missing: 
```
Current branch: main
Release branch name: master
Skipping for main branch
```