### PR TITLE
Fix use of versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
         ssh-passphrase: ${{ secrets.SSH_PASSPHRASE }}
         release-branch-name: "main"
-        maven-release-version-number: ${releaseVersion}
-        maven-development-version-number: ${developmentVersion}
+        maven-release-version-number: ${{ github.event.inputs.releaseVersion }}
+        maven-development-version-number: ${{ github.event.inputs.developmentVersion }}
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:


### PR DESCRIPTION
Fixes
```
Do mvn release:prepare with options  -DdevelopmentVersion=${developmentVersion} -DreleaseVersion=${releaseVersion} and arguments 
ERROR: Could not interpolate properties and/or arguments: Resolving expression: '${developmentVersion}': Detected the following recursive expression cycle in 'developmentVersion': [developmentVersion]
```
https://github.com/lat-lon/sep3-tools/actions/runs/15958737783/job/45008388677