### PR TITLE
#424 - configure git user

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
       run: mvn -B verify --file pom.xml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Configure Git User
+      run: |
+        git config user.email "sep3-tools@github.com"
+        git config user.name "GitHub Action sep3-tools"
     - name: Create Maven Release
       run: mvn -Dresume=false -DreleaseVersion=${{ github.event.inputs.release_version }} -DdevelopmentVersion=${{ github.event.inputs.next_version }} -DdeployAtEnd=true -Dgoals=deploy release:prepare release:perform
       env:


### PR DESCRIPTION
Fixes
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:3.0.1:prepare (default-cli) on project sep3-parser: Unable to commit files
Error:  Provider message:
Error:  The git-commit command failed.
Error:  Command output:
Error:  Author identity unknown
Error:  
Error:  *** Please tell me who you are.
Error:  
Error:  Run
Error:  
Error:    git config --global user.email "you@example.com"
Error:    git config --global user.name "Your Name"
Error:  
Error:  to set your account's default identity.
Error:  Omit --global to set the identity only in this repository.
Error:  
Error:  fatal:********@pkrvmq0rgcvqdmg.hwtsxnfd10pere5w5mrmckzgyb.cx.internal.cloudapp.net>) not allowed
```
https://github.com/lat-lon/sep3-tools/actions/runs/16418456889/job/46390238896