### PR TITLE
Fix filename from downloaded tar.gz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer="lat/lon GmbH <info@lat-lon.de" \
 ARG POSTGRES_VERSION=14
 ARG JDK_VERSION=11
 
-ENV WBFILENAME=/tmp/Woerterbuch_Austausch_Internet_accdb.accdb
+ENV WBFILENAME=/tmp/Woerterbuch_Austausch_Internet.accdb
 
 RUN apt-get update -y && \
    apt-get install --no-install-recommends -y postgresql-${POSTGRES_VERSION}-pljava openjdk-${JDK_VERSION}-jdk mdbtools wget unzip


### PR DESCRIPTION
Suffix `_accdb` was removed from download examples: https://www.lbeg.niedersachsen.de/download/49897

Fixes action https://github.com/lat-lon/sep3-tools/actions/runs/23433259410/job/68164786326
``` 
#17 [12/15] RUN mdb-schema -T Schluesseltypen /tmp/Woerterbuch_Austausch_Internet_accdb.accdb postgres > /tmp/Schluesseltypen_create-table.sql
#17 0.127 File not found
#17 0.127 Could not open file
#17 ERROR: process "/bin/sh -c mdb-schema -T Schluesseltypen $WBFILENAME postgres > /tmp/Schluesseltypen_create-table.sql" did not complete successfully: exit code: 1
------
 > [12/15] RUN mdb-schema -T Schluesseltypen /tmp/Woerterbuch_Austausch_Internet_accdb.accdb postgres > /tmp/Schluesseltypen_create-table.sql:
0.127 File not found
0.127 Could not open file
------
Dockerfile:35
--------------------
  33 |     RUN sed -i "s|'db-1.properties'|'/tmp/db.properties'|g" /tmp/00_dbinfo.sql
  34 |     
  35 | >>> RUN mdb-schema -T Schluesseltypen $WBFILENAME postgres > /tmp/Schluesseltypen_create-table.sql
  36 |     RUN mdb-export $WBFILENAME Schluesseltypen > /tmp/Schluesseltypen.csv
  37 |     RUN mdb-schema -T Woerterbuch $WBFILENAME postgres > /tmp/Woerterbuch_create-table.sql
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c mdb-schema -T Schluesseltypen $WBFILENAME postgres > /tmp/Schluesseltypen_create-table.sql" did not complete successfully: exit code: 1
Reference
Check build summary support
Error: buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c mdb-schema -T Schluesseltypen $WBFILENAME postgres > /tmp/Schluesseltypen_create-table.sql" did not complete successfully: exit code: 1
```